### PR TITLE
Adiciona testes de segurança com base no PR #3 de @matheusalexan

### DIFF
--- a/test/login/login.security.test.js
+++ b/test/login/login.security.test.js
@@ -1,0 +1,37 @@
+const request = require('supertest');
+const { expect } = require('chai');
+const baseURL = process.env.HML_BASE_URL;
+
+describe('POST /login - segurança', () => {
+  it('Deve retornar 400 quando o usuário conter script XSS', async () => {
+    const res = await request(baseURL)
+      .post('/login')
+      .send({ usuario: '<script>alert(1)</script>', senha: '123456' });
+
+    expect(res.status).to.equal(400);
+  });
+
+  it('Deve retornar 400 quando a senha conter script XSS', async () => {
+    const res = await request(baseURL)
+      .post('/login')
+      .send({ usuario: 'admin', senha: '<script>alert(1)</script>' });
+
+    expect(res.status).to.equal(400);
+  });
+
+  it('Deve retornar 400 quando o usuário simular SQL Injection', async () => {
+    const res = await request(baseURL)
+      .post('/login')
+      .send({ usuario: "' OR 1=1 --", senha: 'senha123' });
+
+    expect(res.status).to.equal(400);
+  });
+
+  it('Deve retornar 400 quando a senha simular SQL Injection', async () => {
+    const res = await request(baseURL)
+      .post('/login')
+      .send({ usuario: 'admin', senha: "' OR '1'='1" });
+
+    expect(res.status).to.equal(400);
+  });
+});

--- a/test/login/login.security.test.js
+++ b/test/login/login.security.test.js
@@ -1,37 +1,17 @@
-const request = require('supertest');
-const { expect } = require('chai');
-const baseURL = process.env.HML_BASE_URL;
+const { expect } = require("chai");
+const { makeRequest } = require("./../../helpers/autenticacao.js");
 
 describe('POST /login - segurança', () => {
-  it('Deve retornar 400 quando o usuário conter script XSS', async () => {
-    const res = await request(baseURL)
-      .post('/login')
-      .send({ usuario: '<script>alert(1)</script>', senha: '123456' });
-
-    expect(res.status).to.equal(400);
+  const bodyLogins = [
+    { description: 'usuário', usuario: '<script>alert(1)</script>', senha: '123456', tipo: 'script XSS'},
+    { description: 'senha', usuario: 'admin', senha: '<script>alert(1)</script>', tipo: 'script XSS'},
+    { description: 'usuário', usuario: "' OR 1=1 --", senha: 'senha123', tipo: 'SQL Injection' },
+    { description: 'senha', usuario: 'admin', senha: "' OR '1'='1", tipo: 'SQL Injection' }
+  ]
+  bodyLogins.forEach( (credentials)=>{
+  it(`Deve retornar 400 quando o ${credentials.description} conter ${credentials.tipo}`, async () => {
+    const response = await makeRequest("post", "/login", credentials);
+    expect(response.status).to.equal(400);
   });
-
-  it('Deve retornar 400 quando a senha conter script XSS', async () => {
-    const res = await request(baseURL)
-      .post('/login')
-      .send({ usuario: 'admin', senha: '<script>alert(1)</script>' });
-
-    expect(res.status).to.equal(400);
-  });
-
-  it('Deve retornar 400 quando o usuário simular SQL Injection', async () => {
-    const res = await request(baseURL)
-      .post('/login')
-      .send({ usuario: "' OR 1=1 --", senha: 'senha123' });
-
-    expect(res.status).to.equal(400);
-  });
-
-  it('Deve retornar 400 quando a senha simular SQL Injection', async () => {
-    const res = await request(baseURL)
-      .post('/login')
-      .send({ usuario: 'admin', senha: "' OR '1'='1" });
-
-    expect(res.status).to.equal(400);
-  });
+  })
 });


### PR DESCRIPTION
## Propósito  
Adicionar testes de segurança para XSS e SQL Injection no endpoint **POST /login**, melhorando a cobertura de casos maliciosos. :contentReference[oaicite:1]{index=1}

## O que mudou  
- Novos cenários de XSS e SQL Injection em `test/login/login.security.test.js` :contentReference[oaicite:2]{index=2}  
- Refatoração leve de imports e uso de `makeRequest` do helper de autenticação :contentReference[oaicite:3]{index=3}  

## Contexto e Referências  
Este PR é baseado no PR #3 de @matheusalexan, que adicionou a estrutura inicial dos testes de segurança. :contentReference[oaicite:4]{index=4}

## Créditos  
Co-authored-by: Matheus Alexan <matheusalexan@users.noreply.github.com> :contentReference[oaicite:7]{index=7}  
